### PR TITLE
Recognize alpha-version if it is provided directly

### DIFF
--- a/neoget.sh
+++ b/neoget.sh
@@ -83,7 +83,7 @@ function download {
         fi
         if [ $DOWNLOAD -eq 1 ]
         then
-            if [[ "$ALL_VERSIONS" == "$ALPHA_VERSION" ]]
+            if [[ "$VERSIONS" == "$ALPHA_VERSION" ]]
             then
                 URL="${ALPHA}/${ARCHIVE}"
             else


### PR DESCRIPTION
To download latest alpha, we could both use `./neoget.sh -a` or `./neoget.sh 3.0.0-M01`